### PR TITLE
Unable to upload any number of files after (uploading a single, cancelling it) x 2

### DIFF
--- a/src/uploader/js/uploader-html5.js
+++ b/src/uploader/js/uploader-html5.js
@@ -551,6 +551,10 @@ Y.UploaderHTML5 = Y.extend( UploaderHTML5, Y.Widget, {
            
            this.fire("uploadstart"); 
        }
+       else {
+            this.queue.queuedFiles = this.queue.get('fileList');
+            this.queue._startNextFile();
+       }
     }
 },
 


### PR DESCRIPTION
And along with setting "appendNewFiles: false" on Uploader instantiation, this will take care of the bug in the multi-files uploader demo:

```
problem: unable to upload any number of files

steps to reproduce:
    1. add a single file
    2. upload it
    3. cancel it
    4. repeat steps 1-3 once
    5. add another single file
    6. click upload
```
